### PR TITLE
Fix to make things work with Angular 1.6.1

### DIFF
--- a/LocationSPA/AppScripts/app.js
+++ b/LocationSPA/AppScripts/app.js
@@ -2,12 +2,13 @@
 
 var locationApp = angular.module('locationApp', ['AdalAngular']);
 
-locationApp.config(['$httpProvider', 'adalAuthenticationServiceProvider', function ($httpProvider, adalProvider) {
+locationApp.config(['$locationProvider', '$httpProvider', 'adalAuthenticationServiceProvider', function ($locationProvider, $httpProvider, adalProvider) {
     // endpoints map the address to the Web API to the app registration URI in Azure AD.
     var endpoints = {
         "https://localhost:44309/": "<location-svc-app-id-uri-in-azure-ad>"
     };
 
+    $locationProvider.hashPrefix('');  // Needed for adal.js isCallback function to find id_token
     adalProvider.init({
         instance: 'https://login.microsoftonline.com/',
         tenant: '<your-tenant>.onmicrosoft.com',


### PR DESCRIPTION
Hash prefix override needed for Angular v1.6.1 and up.

See this comment: https://github.com/AzureAD/azure-activedirectory-library-for-js/issues/485#issuecomment-280866096